### PR TITLE
Optimize code

### DIFF
--- a/EasyReact/Classes/Core/EZRMutableNode.m
+++ b/EasyReact/Classes/Core/EZRMutableNode.m
@@ -153,6 +153,11 @@ static inline EZSFliterBlock _EZR_PropertyExists(NSString *keyPath) {
     if EZR_LikelyNO(!self.isMutable) {
         EZR_THROW(EZRNodeExceptionName, EZRExceptionReason_CannotModifyEZRNode, nil);
     }
+#ifdef DEBUG
+    if EZR_LikelyNO(!(self.hasListener || self.hasDownstreamNode)) {
+        NSLog(@"[EasyReact Warning] The node has no listeners .The value is: %@",value);
+    }
+#endif
     [self next:value from:[EZRSenderList new] context:context];
 }
 

--- a/EasyReact/Classes/Core/NodeTransforms/EZRCaseTransform.m
+++ b/EasyReact/Classes/Core/NodeTransforms/EZRCaseTransform.m
@@ -64,13 +64,8 @@ static BOOL EZR_instanceEqual(id left, id right) {
         @ezr_weakify(self)
         self.cancelable = [[next.second listenedBy:self] withSenderListAndContextBlock:^(id  _Nullable value, EZRSenderList * _Nonnull insideSenderList, id  _Nullable insideContext) {
            @ezr_strongify(self)
-            if (self.cancelable) {
-                [self _superNext:value from:insideSenderList context:insideContext];
-            }
+            [self _superNext:value from:insideSenderList context:insideContext];
         }];
-        if (!next.second.isEmpty) {
-            [super next:next.second.value from:[senderList appendNewSender:next.second] context:context];
-        }
     }
 }
 

--- a/EasyReact/Classes/Core/NodeTransforms/EZRSwitchMapTransform.m
+++ b/EasyReact/Classes/Core/NodeTransforms/EZRSwitchMapTransform.m
@@ -60,8 +60,8 @@
                 _switchDictionary[key] = valueNode;
             }
         }
-        [valueNode setValue:mappedValue context:context];
         [super next:EZTuple(key, valueNode) from:senderList context:context];
+        [valueNode setValue:mappedValue context:context];
     }
 }
 

--- a/Example/Tests/EZRNode+Operation.m
+++ b/Example/Tests/EZRNode+Operation.m
@@ -1473,6 +1473,16 @@ describe(@"EZRNode", ^{
         });
     });
     
+    it(@"can use case with out switch", ^{
+        EZRMutableNode<EZTupleBase *> *node = [EZRMutableNode new];
+        EZRNode *caseA = [node case:@"zh"];
+        [caseA startListenForTestWithObj:self];
+        EZRMutableNode<NSString *> *vNode =  [EZRMutableNode new];
+        node.value = EZTuple(@"zh", vNode);
+        vNode.value = @"23333";
+        expect(caseA).to(receive(@[@"23333"]));
+    });
+    
     it(@"can use switch case split value sequence", ^{
         EZRMutableNode<NSString *> *node = [EZRMutableNode value:@"Lilei: hello!"];
         EZRNode<EZRSwitchedNodeTuple<NSString *> *> *nodes = [node switch:^id<NSCopying> _Nonnull(NSString * _Nullable next) {


### PR DESCRIPTION
For that PR [](https://github.com/meituan/EasyReact/pull/32) ,I add warning when set value to no listener node

Modify 1
```
    if EZR_LikelyNO(!(self.hasListener || self.hasDownstreamNode)) {
#if DEBUG
        NSLog(@"[EasyReact Warning] The node has no listeners .The Value is: %@",value);
#endif
    }
```

When I print this warning，I found EZRSwitchMapTransform will make warning

```
        [valueNode setValue:mappedValue context:context]; //set value
        [super next:EZTuple(key, valueNode) from:senderList context:context];  //set listen block
```
I think set listen block should be before the set value

so Modify 2
```
        [super next:EZTuple(key, valueNode) from:senderList context:context];  //set listen block
        [valueNode setValue:mappedValue context:context]; //set value
```

When I implement modify 2，I found EZRCaseTransform.m  has some unnecessary code 
 
```
      self.cancelable = [[next.second listenedBy:self] withSenderListAndContextBlock:^(id  _Nullable value, EZRSenderList * _Nonnull insideSenderList, id  _Nullable insideContext) {
           @ezr_strongify(self)
            if (self.cancelable) { //this judgment seems unnecessary
                [self _superNext:value from:insideSenderList context:insideContext];
            }
        }];
        if (!next.second.isEmpty) {  
            //This code could be a patch for EZRSwitchMapTransform was set value before set listen block
            [super next:next.second.value from:[senderList appendNewSender:next.second] context:context];  
        }
  
```

For this PR. I think  no listeners warning is useful